### PR TITLE
Fixed 'license' field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 description = "Safe wrappers for memory-accessing functions, like `std::ptr::copy()`."
 repository = "https://github.com/abonander/safemem"
 keywords = ["memset", "memmove", "copy"]
-license = "MIT OR Apache-2.0"
+license = "MIT/Apache-2.0"
 
 documentation = "https://docs.rs/safemem"
 


### PR DESCRIPTION
According to [Cargo manifest](http://doc.crates.io/manifest.html):

>Multiple licenses can be separated with a `/`.