### PR TITLE
Added support for no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,13 @@ authors = ["Austin Bonander <austin.bonander@gmail.com>"]
 description = "Safe wrappers for memory-accessing functions, like `std::ptr::copy()`."
 repository = "https://github.com/abonander/safemem"
 keywords = ["memset", "memmove", "copy"]
+categories = ["no-std"]
 license = "MIT/Apache-2.0"
 
 documentation = "https://docs.rs/safemem"
 
 [dependencies]
+
+[features]
+default = ["std"]
+std = []

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # safemem
 Safe wrappers for `memmove`, `memset`, etc. in Rust
 
+`no_std` Support
+----------------
+
+This crate has support for `no_std` which is controlled via default feature `std`. To use the crate
+in a `no_std` environment simply turn off default features.
+
+
 License
 -------
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 //! Safe wrappers for memory-accessing functions like `std::ptr::copy()`.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(not(feature = "std"))]
+extern crate core as std;
 use std::ptr;
 
 macro_rules! idx_check (
@@ -55,6 +60,7 @@ pub fn write_bytes(slice: &mut [u8], byte: u8) {
 ///
 /// ###Panics
 /// If `vec.len() + elems.len()` overflows.
+#[cfg(feature = "std")]
 pub fn prepend<T: Copy>(elems: &[T], vec: &mut Vec<T>) {
     // Our overflow check occurs here, no need to do it ourselves.
     vec.reserve(elems.len());
@@ -94,12 +100,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn prepend_empty() {
         let mut vec: Vec<i32> = vec![];
         prepend(&[1, 2, 3], &mut vec);
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn prepend_i32() {
         let mut vec = vec![3, 4, 5];
         prepend(&[1, 2], &mut vec);


### PR DESCRIPTION
Added `no_std` support. Only `copy_over` function is supported under `no_std` because `prepend` requires a `Vec` which `no_std` can't provide (without using the `alloc` crate at least)