### PR TITLE
Remove UB in copy_over method

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,11 +41,10 @@ pub fn copy_over<T: Copy>(slice: &mut [T], src_idx: usize, dest_idx: usize, len:
     len_check!(slice, src_idx, len);
     len_check!(slice, dest_idx, len);
 
-    let src_ptr: *const T = &slice[src_idx];
-    let dest_ptr: *mut T = &mut slice[dest_idx];
+    let ptr = slice.as_mut_ptr();
 
     unsafe {
-        ptr::copy(src_ptr, dest_ptr, len);
+        ptr::copy(ptr.add(src_idx), ptr.add(dest_idx), len);
     }
 }
 


### PR DESCRIPTION
With current memory model, `&mut` in `dest_ptr` assignment invalidated `src_ptr` (this can be seen in miri). This commit avoids this issue by performing operations on pointers instead, avoiding reference indirection that requires exclusivity.