### PR TITLE
Add a travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly
+  - 1.24.0 # Debian
+  - 1.19.0 # mrustc
+
+script:
+  - cargo build --verbose
+  - cargo test --verbose


### PR DESCRIPTION
Sets the oldest tested version to 1.19.0, the version [mrustc](https://github.com/thepowersgang/mrustc) supports.